### PR TITLE
wolfdisk/s3: real SigV4 auth + multipart, copy, batch delete, range, metadata

### DIFF
--- a/wolfdisk/Cargo.lock
+++ b/wolfdisk/Cargo.lock
@@ -1070,6 +1070,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2459,9 +2469,12 @@ dependencies = [
  "ctrlc",
  "fuser",
  "hex",
+ "hmac",
  "hostname",
  "libc",
  "lz4_flex",
+ "md-5",
+ "percent-encoding",
  "rand",
  "rust-s3",
  "serde",

--- a/wolfdisk/Cargo.toml
+++ b/wolfdisk/Cargo.toml
@@ -24,6 +24,11 @@ toml = "0.8"
 sha2 = "0.10"
 hex = "0.4"
 
+# S3 SigV4 authentication + ETag computation
+hmac = "0.12"
+md-5 = "0.10"
+percent-encoding = "2"
+
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/wolfdisk/src/main.rs
+++ b/wolfdisk/src/main.rs
@@ -2291,6 +2291,7 @@ fn main() {
                 let s3_next_inode = next_inode.clone();
                 let s3_bind = config.s3.bind.clone();
                 let s3_credentials = config.s3.credentials();
+                let s3_meta_path = wolfdisk::s3::meta::meta_path(&config.index_dir());
 
                 std::thread::spawn(move || {
                     let rt = tokio::runtime::Builder::new_multi_thread()
@@ -2307,6 +2308,7 @@ fn main() {
                             s3_inode_table,
                             s3_next_inode,
                             s3_credentials,
+                            s3_meta_path,
                         );
 
                         if let Err(e) = server.run().await {

--- a/wolfdisk/src/s3/auth.rs
+++ b/wolfdisk/src/s3/auth.rs
@@ -1,9 +1,25 @@
-//! S3 authentication
+//! S3 authentication — AWS Signature Version 4 verification.
 //!
-//! Supports optional access key / secret key authentication.
-//! When credentials are not configured, all requests are allowed (internal use).
+//! When no credentials are configured the gateway allows all requests (the
+//! historical private-cluster behaviour). When credentials *are* configured we
+//! perform full SigV4 verification (header-based and presigned query), instead
+//! of merely string-matching the access key.
+//!
+//! The canonical URI is URI-encoded once (the Amazon S3 rule). The payload hash
+//! used in the canonical request is the value the client put in
+//! `x-amz-content-sha256` verbatim, which makes verification independent of the
+//! body and supports `UNSIGNED-PAYLOAD` and `STREAMING-AWS4-HMAC-SHA256-PAYLOAD`.
 
+use axum::http::{HeaderMap, StatusCode};
+use hmac::{Hmac, Mac};
+use percent_encoding::percent_decode_str;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Maximum allowed clock skew between client and server (header auth).
+const MAX_SKEW_SECS: i64 = 15 * 60;
 
 /// S3 credentials
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -12,71 +28,545 @@ pub struct S3Credentials {
     pub secret_key: String,
 }
 
-/// Validate an Authorization header against configured credentials.
-/// Returns true if auth is disabled (no credentials configured) or if the
-/// access key in the header matches. We do a simplified check — full SigV4
-/// verification is complex and not needed for a private cluster.
-pub fn check_auth(
-    auth_header: Option<&str>,
+/// An authentication failure, carrying the S3 error code to report.
+#[derive(Debug)]
+pub struct AuthError {
+    pub status: StatusCode,
+    pub code: &'static str,
+    pub message: String,
+}
+
+impl AuthError {
+    fn forbidden(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::FORBIDDEN,
+            code,
+            message: message.into(),
+        }
+    }
+    fn bad_request(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+/// Verify a request. Returns `Ok(())` when the request is authorised — including
+/// the case where no credentials are configured (auth disabled).
+pub fn verify(
+    method: &str,
+    raw_path: &str,
+    raw_query: &str,
+    headers: &HeaderMap,
     credentials: Option<&S3Credentials>,
-) -> bool {
+) -> Result<(), AuthError> {
     let creds = match credentials {
+        // No credentials configured → auth disabled, allow all.
+        None => return Ok(()),
         Some(c) => c,
-        None => return true, // No auth configured — allow all
     };
 
-    let header = match auth_header {
-        Some(h) => h,
-        None => return false, // Auth required but no header
+    if raw_query.contains("X-Amz-Signature=") {
+        verify_presigned(method, raw_path, raw_query, headers, creds)
+    } else {
+        verify_header(method, raw_path, raw_query, headers, creds)
+    }
+}
+
+fn verify_header(
+    method: &str,
+    raw_path: &str,
+    raw_query: &str,
+    headers: &HeaderMap,
+    creds: &S3Credentials,
+) -> Result<(), AuthError> {
+    let auth = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .ok_or_else(|| AuthError::forbidden("AccessDenied", "Missing Authorization header"))?;
+
+    let rest = auth
+        .strip_prefix("AWS4-HMAC-SHA256 ")
+        .ok_or_else(|| AuthError::forbidden("AccessDenied", "Unsupported authorization scheme"))?;
+
+    let mut credential = None;
+    let mut signed_headers_str = None;
+    let mut provided_sig = None;
+    for part in rest.split(',') {
+        let part = part.trim();
+        if let Some(v) = part.strip_prefix("Credential=") {
+            credential = Some(v.to_string());
+        } else if let Some(v) = part.strip_prefix("SignedHeaders=") {
+            signed_headers_str = Some(v.to_string());
+        } else if let Some(v) = part.strip_prefix("Signature=") {
+            provided_sig = Some(v.to_string());
+        }
+    }
+    let credential = credential
+        .ok_or_else(|| AuthError::bad_request("InvalidArgument", "Missing Credential"))?;
+    let signed_headers_str = signed_headers_str
+        .ok_or_else(|| AuthError::bad_request("InvalidArgument", "Missing SignedHeaders"))?;
+    let provided_sig = provided_sig
+        .ok_or_else(|| AuthError::bad_request("InvalidArgument", "Missing Signature"))?;
+
+    let scope = parse_credential(&credential)?;
+    if scope.access_key != creds.access_key {
+        return Err(AuthError::forbidden(
+            "InvalidAccessKeyId",
+            "The access key Id you provided does not exist in our records.",
+        ));
+    }
+
+    let amz_date = header_value(headers, "x-amz-date")
+        .ok_or_else(|| AuthError::bad_request("InvalidArgument", "Missing x-amz-date"))?;
+    check_skew(&amz_date)?;
+
+    let payload_hash =
+        header_value(headers, "x-amz-content-sha256").unwrap_or_else(|| "UNSIGNED-PAYLOAD".into());
+
+    let signed_headers: Vec<String> = signed_headers_str
+        .split(';')
+        .map(|s| s.to_lowercase())
+        .collect();
+    let canon_headers = canonical_headers(headers, &signed_headers)?;
+    let canon_uri = canonical_uri(raw_path);
+    let canon_query = canonical_query(raw_query, &[]);
+    let canon_hash = canonical_request_hash(
+        method,
+        &canon_uri,
+        &canon_query,
+        &canon_headers,
+        &signed_headers_str,
+        &payload_hash,
+    );
+
+    let credential_scope = format!(
+        "{}/{}/{}/aws4_request",
+        scope.date_stamp, scope.region, scope.service
+    );
+    let sts = string_to_sign(&amz_date, &credential_scope, &canon_hash);
+    let expected = compute_signature(
+        &creds.secret_key,
+        &scope.date_stamp,
+        &scope.region,
+        &scope.service,
+        &sts,
+    );
+
+    if !ct_eq(expected.as_bytes(), provided_sig.as_bytes()) {
+        return Err(AuthError::forbidden(
+            "SignatureDoesNotMatch",
+            "The request signature we calculated does not match the signature you provided.",
+        ));
+    }
+    Ok(())
+}
+
+fn verify_presigned(
+    method: &str,
+    raw_path: &str,
+    raw_query: &str,
+    headers: &HeaderMap,
+    creds: &S3Credentials,
+) -> Result<(), AuthError> {
+    let mut params: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    for kv in raw_query.split('&') {
+        if let Some((k, v)) = kv.split_once('=') {
+            let k = percent_decode_str(k).decode_utf8_lossy().to_string();
+            let v = percent_decode_str(v).decode_utf8_lossy().to_string();
+            params.insert(k, v);
+        }
+    }
+    let get = |name: &str| -> Result<String, AuthError> {
+        params
+            .get(name)
+            .cloned()
+            .ok_or_else(|| AuthError::bad_request("InvalidArgument", format!("Missing {}", name)))
     };
 
-    // Check for AWS4-HMAC-SHA256 signature (extract Credential= access key)
-    if header.starts_with("AWS4-HMAC-SHA256") {
-        if let Some(cred_part) = header.split("Credential=").nth(1) {
-            if let Some(access_key) = cred_part.split('/').next() {
-                return access_key == creds.access_key;
-            }
+    if get("X-Amz-Algorithm")? != "AWS4-HMAC-SHA256" {
+        return Err(AuthError::bad_request(
+            "InvalidArgument",
+            "Unsupported X-Amz-Algorithm",
+        ));
+    }
+    let credential = get("X-Amz-Credential")?;
+    let amz_date = get("X-Amz-Date")?;
+    let signed_headers_str = get("X-Amz-SignedHeaders")?;
+    let provided_sig = get("X-Amz-Signature")?;
+    let expires: i64 = get("X-Amz-Expires")?
+        .parse()
+        .map_err(|_| AuthError::bad_request("InvalidArgument", "Invalid X-Amz-Expires"))?;
+
+    {
+        use chrono::{Duration, NaiveDateTime, Utc};
+        let signed = NaiveDateTime::parse_from_str(&amz_date, "%Y%m%dT%H%M%SZ")
+            .map_err(|_| AuthError::bad_request("InvalidArgument", "Invalid X-Amz-Date"))?;
+        let now = Utc::now().naive_utc();
+        if now > signed + Duration::seconds(expires) {
+            return Err(AuthError::forbidden("AccessDenied", "Request has expired."));
+        }
+        if (now - signed).num_seconds() < -MAX_SKEW_SECS {
+            return Err(AuthError::forbidden(
+                "RequestTimeTooSkewed",
+                "Request time is too skewed.",
+            ));
         }
     }
 
-    // Check for simple AWS access key format: AWS <access_key>:<signature>
-    if header.starts_with("AWS ") {
-        if let Some(key_part) = header.strip_prefix("AWS ") {
-            if let Some(access_key) = key_part.split(':').next() {
-                return access_key == creds.access_key;
-            }
-        }
+    let scope = parse_credential(&credential)?;
+    if scope.access_key != creds.access_key {
+        return Err(AuthError::forbidden(
+            "InvalidAccessKeyId",
+            "The access key Id you provided does not exist in our records.",
+        ));
     }
 
-    false
+    let signed_headers: Vec<String> = signed_headers_str
+        .split(';')
+        .map(|s| s.to_lowercase())
+        .collect();
+    let canon_headers = canonical_headers(headers, &signed_headers)?;
+    let canon_uri = canonical_uri(raw_path);
+    let canon_query = canonical_query(raw_query, &["X-Amz-Signature"]);
+    let canon_hash = canonical_request_hash(
+        method,
+        &canon_uri,
+        &canon_query,
+        &canon_headers,
+        &signed_headers_str,
+        "UNSIGNED-PAYLOAD",
+    );
+
+    let credential_scope = format!(
+        "{}/{}/{}/aws4_request",
+        scope.date_stamp, scope.region, scope.service
+    );
+    let sts = string_to_sign(&amz_date, &credential_scope, &canon_hash);
+    let expected = compute_signature(
+        &creds.secret_key,
+        &scope.date_stamp,
+        &scope.region,
+        &scope.service,
+        &sts,
+    );
+    if !ct_eq(expected.as_bytes(), provided_sig.as_bytes()) {
+        return Err(AuthError::forbidden(
+            "SignatureDoesNotMatch",
+            "The request signature we calculated does not match the signature you provided.",
+        ));
+    }
+    Ok(())
+}
+
+// ─── SigV4 primitives ────────────────────────────────────────────────────────
+
+fn sha256_hex(data: &[u8]) -> String {
+    hex::encode(Sha256::digest(data))
+}
+
+fn hmac_sha256(key: &[u8], data: &[u8]) -> Vec<u8> {
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts any key length");
+    mac.update(data);
+    mac.finalize().into_bytes().to_vec()
+}
+
+fn signing_key(secret: &str, date_stamp: &str, region: &str, service: &str) -> Vec<u8> {
+    let k_date = hmac_sha256(format!("AWS4{}", secret).as_bytes(), date_stamp.as_bytes());
+    let k_region = hmac_sha256(&k_date, region.as_bytes());
+    let k_service = hmac_sha256(&k_region, service.as_bytes());
+    hmac_sha256(&k_service, b"aws4_request")
+}
+
+/// URI-encode per RFC 3986 / SigV4. Slashes preserved when `keep_slash`.
+fn uri_encode(input: &str, keep_slash: bool) -> String {
+    let mut out = String::with_capacity(input.len());
+    for &b in input.as_bytes() {
+        let unreserved =
+            b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b'.' || b == b'~';
+        if unreserved || (keep_slash && b == b'/') {
+            out.push(b as char);
+        } else {
+            out.push('%');
+            out.push_str(&format!("{:02X}", b));
+        }
+    }
+    out
+}
+
+fn canonical_uri(raw_path: &str) -> String {
+    let decoded = percent_decode_str(raw_path).decode_utf8_lossy();
+    let encoded = uri_encode(&decoded, true);
+    if encoded.is_empty() {
+        "/".to_string()
+    } else {
+        encoded
+    }
+}
+
+fn canonical_query(raw_query: &str, exclude: &[&str]) -> String {
+    let mut pairs: Vec<(String, String)> = Vec::new();
+    if !raw_query.is_empty() {
+        for kv in raw_query.split('&') {
+            if kv.is_empty() {
+                continue;
+            }
+            let (k, v) = match kv.split_once('=') {
+                Some((k, v)) => (k, v),
+                None => (kv, ""),
+            };
+            let k_dec = percent_decode_str(k).decode_utf8_lossy().to_string();
+            if exclude.iter().any(|e| e.eq_ignore_ascii_case(&k_dec)) {
+                continue;
+            }
+            let v_dec = percent_decode_str(v).decode_utf8_lossy().to_string();
+            pairs.push((uri_encode(&k_dec, false), uri_encode(&v_dec, false)));
+        }
+    }
+    pairs.sort();
+    pairs
+        .iter()
+        .map(|(k, v)| format!("{}={}", k, v))
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
+fn header_value(headers: &HeaderMap, name: &str) -> Option<String> {
+    let mut values: Vec<String> = Vec::new();
+    for v in headers.get_all(name) {
+        if let Ok(s) = v.to_str() {
+            values.push(collapse_ws(s));
+        }
+    }
+    if values.is_empty() {
+        None
+    } else {
+        Some(values.join(","))
+    }
+}
+
+fn collapse_ws(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut prev_space = false;
+    for ch in s.trim().chars() {
+        if ch == ' ' || ch == '\t' {
+            if !prev_space {
+                out.push(' ');
+            }
+            prev_space = true;
+        } else {
+            out.push(ch);
+            prev_space = false;
+        }
+    }
+    out
+}
+
+fn canonical_headers(headers: &HeaderMap, signed_headers: &[String]) -> Result<String, AuthError> {
+    let mut block = String::new();
+    for name in signed_headers {
+        let value = header_value(headers, name).ok_or_else(|| {
+            AuthError::bad_request(
+                "InvalidArgument",
+                format!("Signed header '{}' not present", name),
+            )
+        })?;
+        block.push_str(name);
+        block.push(':');
+        block.push_str(&value);
+        block.push('\n');
+    }
+    Ok(block)
+}
+
+fn canonical_request_hash(
+    method: &str,
+    canon_uri: &str,
+    canon_query: &str,
+    canon_headers: &str,
+    signed_headers_list: &str,
+    payload_hash: &str,
+) -> String {
+    let canonical_request = format!(
+        "{}\n{}\n{}\n{}\n{}\n{}",
+        method, canon_uri, canon_query, canon_headers, signed_headers_list, payload_hash
+    );
+    sha256_hex(canonical_request.as_bytes())
+}
+
+fn string_to_sign(amz_date: &str, scope: &str, canon_req_hash: &str) -> String {
+    format!(
+        "AWS4-HMAC-SHA256\n{}\n{}\n{}",
+        amz_date, scope, canon_req_hash
+    )
+}
+
+fn compute_signature(
+    secret: &str,
+    date_stamp: &str,
+    region: &str,
+    service: &str,
+    sts: &str,
+) -> String {
+    let key = signing_key(secret, date_stamp, region, service);
+    hex::encode(hmac_sha256(&key, sts.as_bytes()))
+}
+
+/// Constant-time byte comparison (avoids signature timing oracles).
+fn ct_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+struct CredentialScope {
+    access_key: String,
+    date_stamp: String,
+    region: String,
+    service: String,
+}
+
+fn parse_credential(cred: &str) -> Result<CredentialScope, AuthError> {
+    let parts: Vec<&str> = cred.split('/').collect();
+    if parts.len() != 5 || parts[4] != "aws4_request" {
+        return Err(AuthError::bad_request(
+            "InvalidArgument",
+            "Malformed Credential scope",
+        ));
+    }
+    Ok(CredentialScope {
+        access_key: parts[0].to_string(),
+        date_stamp: parts[1].to_string(),
+        region: parts[2].to_string(),
+        service: parts[3].to_string(),
+    })
+}
+
+fn check_skew(amz_date: &str) -> Result<(), AuthError> {
+    use chrono::{NaiveDateTime, Utc};
+    let parsed = NaiveDateTime::parse_from_str(amz_date, "%Y%m%dT%H%M%SZ")
+        .map_err(|_| AuthError::bad_request("InvalidArgument", "Invalid x-amz-date"))?;
+    let now = Utc::now().naive_utc();
+    if (now - parsed).num_seconds().abs() > MAX_SKEW_SECS {
+        return Err(AuthError::forbidden(
+            "RequestTimeTooSkewed",
+            "The difference between the request time and the server's time is too large.",
+        ));
+    }
+    Ok(())
+}
+
+/// Decode an `aws-chunked` (STREAMING-AWS4-HMAC-SHA256-PAYLOAD) body into the
+/// underlying object bytes. Per-chunk signatures are not re-verified (the
+/// request is authenticated by its seed signature); only the framing is
+/// stripped. Wire format per chunk:
+/// `<hex-size>;chunk-signature=<sig>\r\n<payload>\r\n`, ending with a 0-size chunk.
+pub fn decode_aws_chunked(body: &[u8]) -> Result<Vec<u8>, String> {
+    let mut out = Vec::with_capacity(body.len());
+    let mut pos = 0usize;
+    loop {
+        let line_end = find_crlf(body, pos).ok_or("malformed aws-chunked body")?;
+        let line = &body[pos..line_end];
+        let size_str = match line.iter().position(|&b| b == b';') {
+            Some(idx) => &line[..idx],
+            None => line,
+        };
+        let size_text = std::str::from_utf8(size_str)
+            .map_err(|_| "invalid chunk size")?
+            .trim();
+        let size = usize::from_str_radix(size_text, 16).map_err(|_| "invalid chunk size")?;
+        pos = line_end + 2;
+        if size == 0 {
+            break;
+        }
+        if pos + size > body.len() {
+            return Err("truncated aws-chunked body".into());
+        }
+        out.extend_from_slice(&body[pos..pos + size]);
+        pos += size;
+        if body.get(pos) == Some(&b'\r') && body.get(pos + 1) == Some(&b'\n') {
+            pos += 2;
+        } else {
+            return Err("missing chunk terminator".into());
+        }
+    }
+    Ok(out)
+}
+
+fn find_crlf(buf: &[u8], start: usize) -> Option<usize> {
+    let mut i = start;
+    while i + 1 < buf.len() {
+        if buf[i] == b'\r' && buf[i + 1] == b'\n' {
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    // AWS-published S3 GET example. Ground-truth signature computed
+    // independently with a reference HMAC implementation.
     #[test]
-    fn test_no_auth_configured() {
-        assert!(check_auth(None, None));
-        assert!(check_auth(Some("anything"), None));
+    fn aws_published_get_object_vector() {
+        let secret = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
+        let canonical_request = "GET\n/test.txt\n\nhost:examplebucket.s3.amazonaws.com\nrange:bytes=0-9\nx-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\nx-amz-date:20130524T000000Z\n\nhost;range;x-amz-content-sha256;x-amz-date\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        let canon_hash = sha256_hex(canonical_request.as_bytes());
+        assert_eq!(
+            canon_hash,
+            "7344ae5b7ee6c3e7e6b0fe0640412a37625d1fbfff95c48bbb2dc43964946972"
+        );
+        let scope = "20130524/us-east-1/s3/aws4_request";
+        let sts = string_to_sign("20130524T000000Z", scope, &canon_hash);
+        let sig = compute_signature(secret, "20130524", "us-east-1", "s3", &sts);
+        assert_eq!(
+            sig,
+            "67fe34c8530db585abddc51067328adfedb6e42487d2566dc7d927d6e2722900"
+        );
     }
 
     #[test]
-    fn test_auth_required_no_header() {
-        let creds = S3Credentials {
-            access_key: "AKID".to_string(),
-            secret_key: "secret".to_string(),
-        };
-        assert!(!check_auth(None, Some(&creds)));
+    fn no_credentials_allows_all() {
+        let headers = HeaderMap::new();
+        assert!(verify("GET", "/", "", &headers, None).is_ok());
     }
 
     #[test]
-    fn test_aws4_auth() {
+    fn missing_auth_denied_when_creds_set() {
         let creds = S3Credentials {
-            access_key: "AKID".to_string(),
-            secret_key: "secret".to_string(),
+            access_key: "AKID".into(),
+            secret_key: "secret".into(),
         };
-        let header = "AWS4-HMAC-SHA256 Credential=AKID/20260211/us-east-1/s3/aws4_request";
-        assert!(check_auth(Some(header), Some(&creds)));
+        let headers = HeaderMap::new();
+        assert!(verify("GET", "/", "", &headers, Some(&creds)).is_err());
+    }
+
+    #[test]
+    fn uri_encode_rules() {
+        assert_eq!(uri_encode("/a b/c.txt", true), "/a%20b/c.txt");
+        assert_eq!(uri_encode("a/b", false), "a%2Fb");
+    }
+
+    #[test]
+    fn aws_chunked_roundtrip() {
+        let body = b"5;chunk-signature=x\r\nhello\r\n6;chunk-signature=y\r\n world\r\n0;chunk-signature=z\r\n\r\n";
+        assert_eq!(decode_aws_chunked(body).unwrap(), b"hello world");
+    }
+
+    #[test]
+    fn ct_eq_works() {
+        assert!(ct_eq(b"abc", b"abc"));
+        assert!(!ct_eq(b"abc", b"abd"));
+        assert!(!ct_eq(b"abc", b"ab"));
     }
 }

--- a/wolfdisk/src/s3/meta.rs
+++ b/wolfdisk/src/s3/meta.rs
@@ -1,0 +1,192 @@
+//! S3-specific object metadata sidecar + multipart upload registry.
+//!
+//! These live entirely within the S3 module so the shared `FileEntry`/index/
+//! replication types are left untouched. Object content, size and chunks are
+//! stored in the normal WolfDisk index (and replicate as usual); only the
+//! S3-flavoured extras — Content-Type, the S3 ETag, and `x-amz-meta-*` user
+//! metadata — are kept here, keyed by `"bucket/key"`.
+//!
+//! Consequence (documented): S3 metadata is node-local — it is not carried by
+//! the replication wire protocol, exactly like the existing `symlink_target`
+//! field. Objects still replicate; their S3 metadata is reconstructed with
+//! defaults on other nodes.
+
+use std::collections::{BTreeMap, HashMap};
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::storage::ChunkRef;
+
+/// S3 metadata for a single object.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct S3ObjectMeta {
+    #[serde(default)]
+    pub content_type: Option<String>,
+    /// S3 ETag without surrounding quotes (hex MD5, or `<hex>-<n>` for multipart).
+    #[serde(default)]
+    pub etag: Option<String>,
+    #[serde(default)]
+    pub user_meta: HashMap<String, String>,
+}
+
+/// Persistent sidecar map of `"bucket/key"` → metadata.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct S3MetaStore {
+    entries: HashMap<String, S3ObjectMeta>,
+}
+
+impl S3MetaStore {
+    /// Load the sidecar from `path`, or start empty if it doesn't exist / can't
+    /// be parsed (best-effort; never fatal).
+    pub fn load(path: &Path) -> Self {
+        match std::fs::read(path) {
+            Ok(bytes) => serde_json::from_slice(&bytes).unwrap_or_default(),
+            Err(_) => Self::default(),
+        }
+    }
+
+    /// Persist atomically (temp file + rename). Best-effort.
+    pub fn save(&self, path: &Path) -> std::io::Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let tmp = path.with_extension("json.tmp");
+        let data = serde_json::to_vec_pretty(self).map_err(std::io::Error::other)?;
+        std::fs::write(&tmp, &data)?;
+        std::fs::rename(&tmp, path)
+    }
+
+    pub fn get(&self, key: &str) -> Option<&S3ObjectMeta> {
+        self.entries.get(key)
+    }
+
+    pub fn put(&mut self, key: String, meta: S3ObjectMeta) {
+        self.entries.insert(key, meta);
+    }
+
+    pub fn remove(&mut self, key: &str) {
+        self.entries.remove(key);
+    }
+}
+
+/// In-progress multipart upload (in-memory only; aborted on restart).
+#[derive(Debug, Clone)]
+pub struct MultipartUpload {
+    pub bucket: String,
+    pub key: String,
+    pub content_type: Option<String>,
+    pub user_meta: HashMap<String, String>,
+    /// part number → uploaded part
+    pub parts: BTreeMap<u32, PartInfo>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PartInfo {
+    /// Chunk refs with offsets relative to the start of the part.
+    pub chunks: Vec<ChunkRef>,
+    /// Hex MD5 of the part data (the part ETag).
+    pub md5_hex: String,
+    pub size: u64,
+}
+
+/// Build the sidecar file path for a data directory's index dir.
+pub fn meta_path(index_dir: &Path) -> PathBuf {
+    index_dir.join("s3_meta.json")
+}
+
+// ─── Tolerant XML parsing for request bodies ─────────────────────────────────
+
+fn unescape_xml(s: &str) -> String {
+    s.replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&apos;", "'")
+}
+
+/// Extract the text content of the first `<tag>...</tag>` within `block`.
+fn extract_tag(block: &str, tag: &str) -> Option<String> {
+    let open = format!("<{}>", tag);
+    let close = format!("</{}>", tag);
+    let s = block.find(&open)? + open.len();
+    let e = block[s..].find(&close)? + s;
+    Some(unescape_xml(&block[s..e]))
+}
+
+/// Parse a CompleteMultipartUpload body into ordered `(part_number, etag)` pairs.
+pub fn parse_complete_multipart(body: &[u8]) -> Result<Vec<(u32, String)>, String> {
+    let s = std::str::from_utf8(body).map_err(|_| "invalid UTF-8".to_string())?;
+    let mut parts = Vec::new();
+    let mut idx = 0;
+    while let Some(rel) = s[idx..].find("<Part>") {
+        let start = idx + rel;
+        let end_rel = s[start..].find("</Part>").ok_or("unterminated <Part>")?;
+        let end = start + end_rel;
+        let block = &s[start..end];
+        let num = extract_tag(block, "PartNumber").ok_or("missing PartNumber")?;
+        let etag = extract_tag(block, "ETag").ok_or("missing ETag")?;
+        let num: u32 = num.trim().parse().map_err(|_| "invalid PartNumber")?;
+        parts.push((num, etag.trim().trim_matches('"').to_string()));
+        idx = end + "</Part>".len();
+    }
+    if parts.is_empty() {
+        return Err("no parts in CompleteMultipartUpload".to_string());
+    }
+    Ok(parts)
+}
+
+/// Parse a DeleteObjects body into `(keys, quiet)`.
+pub fn parse_delete(body: &[u8]) -> Result<(Vec<String>, bool), String> {
+    let s = std::str::from_utf8(body).map_err(|_| "invalid UTF-8".to_string())?;
+    let quiet = extract_tag(s, "Quiet")
+        .map(|v| v.trim().eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+    let mut keys = Vec::new();
+    let mut idx = 0;
+    while let Some(rel) = s[idx..].find("<Object>") {
+        let start = idx + rel;
+        let end_rel = s[start..]
+            .find("</Object>")
+            .ok_or("unterminated <Object>")?;
+        let end = start + end_rel;
+        let block = &s[start..end];
+        if let Some(key) = extract_tag(block, "Key") {
+            keys.push(key);
+        }
+        idx = end + "</Object>".len();
+    }
+    Ok((keys, quiet))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_complete_multipart_ok() {
+        let xml = r#"<CompleteMultipartUpload>
+            <Part><PartNumber>1</PartNumber><ETag>"abc"</ETag></Part>
+            <Part><PartNumber>2</PartNumber><ETag>def</ETag></Part>
+        </CompleteMultipartUpload>"#;
+        let parts = parse_complete_multipart(xml.as_bytes()).unwrap();
+        assert_eq!(parts, vec![(1, "abc".into()), (2, "def".into())]);
+    }
+
+    #[test]
+    fn parse_delete_ok() {
+        let xml = r#"<Delete><Quiet>true</Quiet>
+            <Object><Key>a/b.txt</Key></Object>
+            <Object><Key>c.txt</Key></Object></Delete>"#;
+        let (keys, quiet) = parse_delete(xml.as_bytes()).unwrap();
+        assert!(quiet);
+        assert_eq!(keys, vec!["a/b.txt".to_string(), "c.txt".to_string()]);
+    }
+
+    #[test]
+    fn unescape_in_key() {
+        let xml = "<Delete><Object><Key>a&amp;b.txt</Key></Object></Delete>";
+        let (keys, _) = parse_delete(xml.as_bytes()).unwrap();
+        assert_eq!(keys, vec!["a&b.txt".to_string()]);
+    }
+}

--- a/wolfdisk/src/s3/mod.rs
+++ b/wolfdisk/src/s3/mod.rs
@@ -6,5 +6,6 @@
 
 pub mod server;
 pub mod auth;
+pub mod meta;
 
 pub use server::S3Server;

--- a/wolfdisk/src/s3/server.rs
+++ b/wolfdisk/src/s3/server.rs
@@ -3,29 +3,36 @@
 //! Maps WolfDisk's file index and chunk store to S3 buckets and objects:
 //! - Top-level directories → S3 buckets
 //! - Files within directories → S3 objects
-//! - Files at root level → objects in a virtual "default" bucket
 //!
-//! Supports: ListBuckets, ListObjectsV2, GetObject, PutObject, DeleteObject,
-//! HeadObject, HeadBucket, CreateBucket, DeleteBucket
+//! Supports: ListBuckets, ListObjectsV2 (prefix/delimiter), GetObject (+Range),
+//! PutObject, HeadObject, DeleteObject, HeadBucket, CreateBucket, DeleteBucket,
+//! CopyObject, DeleteObjects (batch), multipart upload (Create/UploadPart/
+//! Complete/Abort), and `x-amz-meta-*` user metadata. Authentication is AWS
+//! SigV4 (header + presigned) when credentials are configured.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use axum::{
     body::Body,
-    extract::{Path, Query, State},
+    extract::{OriginalUri, Path, Query, State},
     http::{header, HeaderMap, Method, Request, StatusCode},
     response::{IntoResponse, Response},
     routing::any,
     Router,
 };
+use md5::{Digest, Md5};
 use tokio::net::TcpListener;
-use tracing::{info, error, debug};
+use tracing::{error, info};
 
-use crate::storage::{ChunkStore, FileIndex, FileEntry, ChunkRef, InodeTable};
-use super::auth::{S3Credentials, check_auth};
+use super::auth::{self, S3Credentials};
+use super::meta::{self, MultipartUpload, PartInfo, S3MetaStore, S3ObjectMeta};
+use crate::storage::{ChunkRef, ChunkStore, FileEntry, FileIndex, InodeTable};
+
+/// Maximum body buffered in memory for a single PutObject / UploadPart.
+const MAX_BODY: usize = 512 * 1024 * 1024;
 
 /// Shared state for the S3 server
 #[derive(Clone)]
@@ -36,6 +43,12 @@ pub struct S3State {
     pub next_inode: Arc<RwLock<u64>>,
     pub credentials: Option<S3Credentials>,
     pub region: String,
+    /// In-progress multipart uploads (in-memory; uploadId → state).
+    pub multipart: Arc<RwLock<HashMap<String, MultipartUpload>>>,
+    /// Persistent S3 object metadata sidecar.
+    pub meta: Arc<RwLock<S3MetaStore>>,
+    /// Path the sidecar is persisted to.
+    pub meta_path: PathBuf,
 }
 
 /// S3 server that runs alongside WolfDisk FUSE
@@ -45,7 +58,9 @@ pub struct S3Server {
 }
 
 impl S3Server {
-    /// Create a new S3 server
+    /// Create a new S3 server. `meta_path` is where S3 object metadata is
+    /// persisted (typically `<data_dir>/index/s3_meta.json`).
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         bind_addr: String,
         file_index: Arc<RwLock<FileIndex>>,
@@ -53,7 +68,9 @@ impl S3Server {
         inode_table: Arc<RwLock<InodeTable>>,
         next_inode: Arc<RwLock<u64>>,
         credentials: Option<S3Credentials>,
+        meta_path: PathBuf,
     ) -> Self {
+        let meta = S3MetaStore::load(&meta_path);
         let state = S3State {
             file_index,
             chunk_store,
@@ -61,6 +78,9 @@ impl S3Server {
             next_inode,
             credentials,
             region: "us-east-1".to_string(),
+            multipart: Arc::new(RwLock::new(HashMap::new())),
+            meta: Arc::new(RwLock::new(meta)),
+            meta_path,
         };
 
         Self { bind_addr, state }
@@ -69,9 +89,9 @@ impl S3Server {
     /// Start the S3 server (call from a tokio runtime)
     pub async fn run(self) -> std::io::Result<()> {
         let app = Router::new()
-            // Catch-all route — S3 routing is path-based
             .route("/", any(handle_root))
-            .route("/{*path}", any(handle_path))
+            // axum 0.7 / matchit 0.7 catch-all syntax (`/*path`, not `/{*path}`).
+            .route("/*path", any(handle_path))
             .with_state(self.state.clone());
 
         info!("S3-compatible API listening on {}", self.bind_addr);
@@ -83,44 +103,65 @@ impl S3Server {
     }
 }
 
+// ─── Auth wrapper ────────────────────────────────────────────────────────────
+
+/// Verify SigV4. Returns a small `AuthError` (mapped to a response by callers).
+fn check(
+    state: &S3State,
+    method: &Method,
+    uri: &axum::http::Uri,
+    headers: &HeaderMap,
+) -> Result<(), auth::AuthError> {
+    auth::verify(
+        method.as_str(),
+        uri.path(),
+        uri.query().unwrap_or(""),
+        headers,
+        state.credentials.as_ref(),
+    )
+}
+
 // ─── Root handler (ListBuckets) ──────────────────────────────────────────────
 
 async fn handle_root(
     State(state): State<S3State>,
+    OriginalUri(uri): OriginalUri,
     headers: HeaderMap,
     method: Method,
 ) -> Response {
-    if !authorize(&headers, &state.credentials) {
-        return error_response(StatusCode::FORBIDDEN, "AccessDenied", "Access Denied");
+    if let Err(e) = check(&state, &method, &uri, &headers) {
+        return error_response(e.status, e.code, &e.message);
     }
-
     match method {
         Method::GET => list_buckets(state).await,
-        _ => error_response(StatusCode::METHOD_NOT_ALLOWED, "MethodNotAllowed", "Method not allowed"),
+        _ => error_response(
+            StatusCode::METHOD_NOT_ALLOWED,
+            "MethodNotAllowed",
+            "Method not allowed",
+        ),
     }
 }
 
-// ─── Path handler (dispatches to bucket or object operations) ────────────────
+// ─── Path handler ────────────────────────────────────────────────────────────
 
 async fn handle_path(
     State(state): State<S3State>,
+    OriginalUri(uri): OriginalUri,
     Path(path): Path<String>,
     headers: HeaderMap,
     method: Method,
     query: Query<HashMap<String, String>>,
     request: Request<Body>,
 ) -> Response {
-    if !authorize(&headers, &state.credentials) {
-        return error_response(StatusCode::FORBIDDEN, "AccessDenied", "Access Denied");
+    if let Err(e) = check(&state, &method, &uri, &headers) {
+        return error_response(e.status, e.code, &e.message);
     }
 
-    // Parse bucket and key from path
     let (bucket, key) = parse_bucket_key(&path);
 
     match (method, key) {
-        // ── Bucket-level operations ────────────────────────────
+        // ── Bucket-level ────────────────────────────────────────
         (Method::GET, None) => {
-            // Could be ListObjectsV2 or GetBucketLocation
             if query.contains_key("location") {
                 get_bucket_location(state).await
             } else {
@@ -130,82 +171,143 @@ async fn handle_path(
         (Method::HEAD, None) => head_bucket(state, &bucket).await,
         (Method::PUT, None) => create_bucket(state, &bucket).await,
         (Method::DELETE, None) => delete_bucket(state, &bucket).await,
+        (Method::POST, None) => {
+            if query.contains_key("delete") {
+                match read_body(request, &headers).await {
+                    Ok(body) => delete_objects(state, &bucket, &body).await,
+                    Err(resp) => resp,
+                }
+            } else {
+                error_response(
+                    StatusCode::METHOD_NOT_ALLOWED,
+                    "MethodNotAllowed",
+                    "Method not allowed",
+                )
+            }
+        }
 
-        // ── Object-level operations ────────────────────────────
-        (Method::GET, Some(key)) => get_object(state, &bucket, &key).await,
+        // ── Object-level ────────────────────────────────────────
+        (Method::GET, Some(key)) => get_object(state, &bucket, &key, &headers).await,
         (Method::HEAD, Some(key)) => head_object(state, &bucket, &key).await,
         (Method::PUT, Some(key)) => {
-            // Read the body
-            let body_bytes = match axum::body::to_bytes(request.into_body(), 512 * 1024 * 1024).await {
-                Ok(b) => b,
-                Err(e) => {
-                    return error_response(
-                        StatusCode::BAD_REQUEST,
-                        "InvalidRequest",
-                        &format!("Failed to read body: {}", e),
-                    );
-                }
-            };
-            put_object(state, &bucket, &key, body_bytes.to_vec()).await
+            // CopyObject (no body)
+            if let Some(src) = headers
+                .get("x-amz-copy-source")
+                .and_then(|v| v.to_str().ok())
+            {
+                let src = src.to_string();
+                return copy_object(state, &bucket, &key, &src, &headers).await;
+            }
+            // UploadPart
+            if let (Some(pn), Some(uid)) = (query.get("partNumber"), query.get("uploadId")) {
+                let pn = pn.clone();
+                let uid = uid.clone();
+                return match read_body(request, &headers).await {
+                    Ok(body) => upload_part(state, &uid, &pn, body).await,
+                    Err(resp) => resp,
+                };
+            }
+            // PutObject
+            match read_body(request, &headers).await {
+                Ok(body) => put_object(state, &bucket, &key, body, &headers).await,
+                Err(resp) => resp,
+            }
         }
-        (Method::DELETE, Some(key)) => delete_object(state, &bucket, &key).await,
+        (Method::POST, Some(key)) => {
+            if query.contains_key("uploads") {
+                create_multipart(state, &bucket, &key, &headers).await
+            } else if let Some(uid) = query.get("uploadId") {
+                let uid = uid.clone();
+                match read_body(request, &headers).await {
+                    Ok(body) => complete_multipart(state, &bucket, &key, &uid, &body).await,
+                    Err(resp) => resp,
+                }
+            } else {
+                error_response(
+                    StatusCode::METHOD_NOT_ALLOWED,
+                    "MethodNotAllowed",
+                    "Method not allowed",
+                )
+            }
+        }
+        (Method::DELETE, Some(key)) => {
+            if let Some(uid) = query.get("uploadId") {
+                abort_multipart(state, uid).await
+            } else {
+                delete_object(state, &bucket, &key).await
+            }
+        }
 
-        _ => error_response(StatusCode::METHOD_NOT_ALLOWED, "MethodNotAllowed", "Method not allowed"),
+        _ => error_response(
+            StatusCode::METHOD_NOT_ALLOWED,
+            "MethodNotAllowed",
+            "Method not allowed",
+        ),
     }
 }
 
-// ─── S3 Operations ───────────────────────────────────────────────────────────
+/// Read (and aws-chunked-decode if needed) a request body.
+async fn read_body(request: Request<Body>, headers: &HeaderMap) -> Result<Vec<u8>, Response> {
+    let streaming = is_streaming(headers);
+    let bytes = match axum::body::to_bytes(request.into_body(), MAX_BODY).await {
+        Ok(b) => b,
+        Err(e) => {
+            return Err(error_response(
+                StatusCode::BAD_REQUEST,
+                "InvalidRequest",
+                &format!("Failed to read body: {}", e),
+            ));
+        }
+    };
+    if streaming {
+        auth::decode_aws_chunked(&bytes)
+            .map_err(|e| error_response(StatusCode::BAD_REQUEST, "InvalidRequest", &e))
+    } else {
+        Ok(bytes.to_vec())
+    }
+}
+
+// ─── Bucket operations ───────────────────────────────────────────────────────
 
 /// GET / → ListBuckets
 async fn list_buckets(state: S3State) -> Response {
     let index = state.file_index.read().unwrap();
 
-    // Collect unique top-level directories as buckets
     let mut buckets: HashSet<String> = HashSet::new();
     for (path, entry) in index.iter() {
         if entry.is_dir {
-            // Top-level dirs become buckets
-            let components: Vec<_> = path.components().collect();
-            if components.len() == 1 {
+            if path.components().count() == 1 {
                 if let Some(name) = path.file_name() {
                     buckets.insert(name.to_string_lossy().to_string());
                 }
             }
-        } else {
-            // Files at root level — infer bucket from first component
+        } else if path.components().count() > 1 {
             if let Some(first) = path.components().next() {
-                let first_str = first.as_os_str().to_string_lossy().to_string();
-                // Only count as a bucket if there are more components (i.e., it's inside a dir)
-                if path.components().count() > 1 {
-                    buckets.insert(first_str);
-                }
+                buckets.insert(first.as_os_str().to_string_lossy().to_string());
             }
         }
     }
 
     let mut xml = String::from("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
     xml.push_str("<ListAllMyBucketsResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n");
-    xml.push_str("  <Owner>\n");
-    xml.push_str("    <ID>wolfdisk</ID>\n");
-    xml.push_str("    <DisplayName>WolfDisk</DisplayName>\n");
-    xml.push_str("  </Owner>\n");
+    xml.push_str(
+        "  <Owner>\n    <ID>wolfdisk</ID>\n    <DisplayName>WolfDisk</DisplayName>\n  </Owner>\n",
+    );
     xml.push_str("  <Buckets>\n");
-
     for bucket_name in &buckets {
         xml.push_str("    <Bucket>\n");
         xml.push_str(&format!("      <Name>{}</Name>\n", xml_escape(bucket_name)));
         xml.push_str("      <CreationDate>2025-01-01T00:00:00.000Z</CreationDate>\n");
         xml.push_str("    </Bucket>\n");
     }
-
-    xml.push_str("  </Buckets>\n");
-    xml.push_str("</ListAllMyBucketsResult>");
+    xml.push_str("  </Buckets>\n</ListAllMyBucketsResult>");
 
     (
         StatusCode::OK,
         [(header::CONTENT_TYPE, "application/xml")],
         xml,
-    ).into_response()
+    )
+        .into_response()
 }
 
 /// GET /bucket?location → GetBucketLocation
@@ -215,20 +317,16 @@ async fn get_bucket_location(state: S3State) -> Response {
          <LocationConstraint xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">{}</LocationConstraint>",
         state.region
     );
-
     (
         StatusCode::OK,
         [(header::CONTENT_TYPE, "application/xml")],
         xml,
-    ).into_response()
+    )
+        .into_response()
 }
 
 /// GET /bucket → ListObjectsV2
-async fn list_objects(
-    state: S3State,
-    bucket: &str,
-    query: &HashMap<String, String>,
-) -> Response {
+async fn list_objects(state: S3State, bucket: &str, query: &HashMap<String, String>) -> Response {
     let prefix = query.get("prefix").cloned().unwrap_or_default();
     let delimiter = query.get("delimiter").cloned().unwrap_or_default();
     let max_keys: usize = query
@@ -240,30 +338,22 @@ async fn list_objects(
     let index = state.file_index.read().unwrap();
     let bucket_prefix = PathBuf::from(bucket);
 
-    let mut objects: Vec<(String, &FileEntry)> = Vec::new();
+    let mut objects: Vec<(String, u64, SystemTime, Vec<ChunkRef>)> = Vec::new();
     let mut common_prefixes: HashSet<String> = HashSet::new();
 
     for (path, entry) in index.iter() {
-        // Only include files under this bucket
         if !path.starts_with(&bucket_prefix) {
             continue;
         }
-
-        // Get the key (path relative to the bucket)
         let key = path
             .strip_prefix(&bucket_prefix)
             .unwrap()
             .to_string_lossy()
             .to_string();
-
-        // Skip the bucket directory itself
         if key.is_empty() {
             continue;
         }
-
-        // Skip directory entries themselves (they show up as common prefixes)
         if entry.is_dir {
-            // If there is a delimiter, add as common prefix
             if !delimiter.is_empty() {
                 let dir_prefix = format!("{}/", key.trim_end_matches('/'));
                 if dir_prefix.starts_with(&prefix) {
@@ -272,13 +362,9 @@ async fn list_objects(
             }
             continue;
         }
-
-        // Apply prefix filter
         if !key.starts_with(&prefix) {
             continue;
         }
-
-        // Handle delimiter (directory grouping)
         if !delimiter.is_empty() {
             let after_prefix = &key[prefix.len()..];
             if let Some(delim_pos) = after_prefix.find(&delimiter) {
@@ -287,16 +373,17 @@ async fn list_objects(
                 continue;
             }
         }
-
-        objects.push((key, entry));
+        objects.push((key, entry.size, entry.modified, entry.chunks.clone()));
     }
+    drop(index);
 
-    // Sort by key
     objects.sort_by(|a, b| a.0.cmp(&b.0));
 
-    // Apply continuation token (simple: skip until we find the token key)
     if let Some(ref token) = continuation_token {
-        if let Some(pos) = objects.iter().position(|(k, _)| k.as_str() > token.as_str()) {
+        if let Some(pos) = objects
+            .iter()
+            .position(|(k, ..)| k.as_str() > token.as_str())
+        {
             objects = objects.split_off(pos);
         } else {
             objects.clear();
@@ -305,9 +392,8 @@ async fn list_objects(
 
     let is_truncated = objects.len() > max_keys;
     let objects: Vec<_> = objects.into_iter().take(max_keys).collect();
-
     let next_token = if is_truncated {
-        objects.last().map(|(k, _)| k.clone())
+        objects.last().map(|(k, ..)| k.clone())
     } else {
         None
     };
@@ -317,34 +403,36 @@ async fn list_objects(
     xml.push_str(&format!("  <Name>{}</Name>\n", xml_escape(bucket)));
     xml.push_str(&format!("  <Prefix>{}</Prefix>\n", xml_escape(&prefix)));
     xml.push_str(&format!("  <MaxKeys>{}</MaxKeys>\n", max_keys));
+    if !delimiter.is_empty() {
+        xml.push_str(&format!(
+            "  <Delimiter>{}</Delimiter>\n",
+            xml_escape(&delimiter)
+        ));
+    }
     xml.push_str(&format!("  <IsTruncated>{}</IsTruncated>\n", is_truncated));
-    xml.push_str("  <KeyCount>");
-    xml.push_str(&objects.len().to_string());
-    xml.push_str("</KeyCount>\n");
-
+    xml.push_str(&format!("  <KeyCount>{}</KeyCount>\n", objects.len()));
     if let Some(ref token) = next_token {
-        xml.push_str(&format!("  <NextContinuationToken>{}</NextContinuationToken>\n", xml_escape(token)));
+        xml.push_str(&format!(
+            "  <NextContinuationToken>{}</NextContinuationToken>\n",
+            xml_escape(token)
+        ));
     }
 
-    for (key, entry) in &objects {
+    let meta = state.meta.read().unwrap();
+    for (key, size, modified, chunks) in &objects {
+        let etag = object_etag(&meta, bucket, key, chunks);
         xml.push_str("  <Contents>\n");
         xml.push_str(&format!("    <Key>{}</Key>\n", xml_escape(key)));
-        xml.push_str(&format!("    <Size>{}</Size>\n", entry.size));
-        xml.push_str(&format!("    <LastModified>{}</LastModified>\n", format_time(&entry.modified)));
-        xml.push_str("    <StorageClass>STANDARD</StorageClass>\n");
-
-        // ETag: use hash of first chunk if available, else empty
-        let etag = if let Some(chunk) = entry.chunks.first() {
-            format!("\"{}\"", hex::encode(&chunk.hash[..16]))
-        } else {
-            "\"d41d8cd98f00b204e9800998ecf8427e\"".to_string() // MD5 of empty
-        };
-        xml.push_str(&format!("    <ETag>{}</ETag>\n", etag));
-
-        xml.push_str("  </Contents>\n");
+        xml.push_str(&format!("    <Size>{}</Size>\n", size));
+        xml.push_str(&format!(
+            "    <LastModified>{}</LastModified>\n",
+            format_time(modified)
+        ));
+        xml.push_str(&format!("    <ETag>\"{}\"</ETag>\n", etag));
+        xml.push_str("    <StorageClass>STANDARD</StorageClass>\n  </Contents>\n");
     }
+    drop(meta);
 
-    // Common prefixes
     let mut sorted_prefixes: Vec<_> = common_prefixes.into_iter().collect();
     sorted_prefixes.sort();
     for cp in &sorted_prefixes {
@@ -352,84 +440,64 @@ async fn list_objects(
         xml.push_str(&format!("    <Prefix>{}</Prefix>\n", xml_escape(cp)));
         xml.push_str("  </CommonPrefixes>\n");
     }
-
     xml.push_str("</ListBucketResult>");
 
     (
         StatusCode::OK,
         [(header::CONTENT_TYPE, "application/xml")],
         xml,
-    ).into_response()
+    )
+        .into_response()
 }
 
 /// HEAD /bucket → HeadBucket
 async fn head_bucket(state: S3State, bucket: &str) -> Response {
     let index = state.file_index.read().unwrap();
     let bucket_path = PathBuf::from(bucket);
-
-    // Check if bucket exists (as a directory or has any files underneath)
     let exists = index.get(&bucket_path).map(|e| e.is_dir).unwrap_or(false)
         || index.iter().any(|(p, _)| p.starts_with(&bucket_path));
-
     if exists {
         (StatusCode::OK, [(header::CONTENT_TYPE, "application/xml")]).into_response()
     } else {
-        error_response(StatusCode::NOT_FOUND, "NoSuchBucket", "The specified bucket does not exist")
+        error_response(
+            StatusCode::NOT_FOUND,
+            "NoSuchBucket",
+            "The specified bucket does not exist",
+        )
     }
 }
 
 /// PUT /bucket → CreateBucket
 async fn create_bucket(state: S3State, bucket: &str) -> Response {
     let bucket_path = PathBuf::from(bucket);
-
     {
         let mut index = state.file_index.write().unwrap();
         let mut inode_tbl = state.inode_table.write().unwrap();
-
         if index.contains(&bucket_path) {
             return error_response(
                 StatusCode::CONFLICT,
-                "BucketAlreadyExists",
+                "BucketAlreadyOwnedByYou",
                 "The requested bucket already exists",
             );
         }
-
-        let now = SystemTime::now();
-        let entry = FileEntry {
-            size: 0,
-            is_dir: true,
-            permissions: 0o755,
-            uid: 0,
-            gid: 0,
-            created: now,
-            modified: now,
-            accessed: now,
-            chunks: Vec::new(),
-            symlink_target: None,
-        };
-
-        index.insert(bucket_path.clone(), entry);
-
-        // Allocate inode
+        index.insert(bucket_path.clone(), new_dir_entry());
         let mut next_ino = state.next_inode.write().unwrap();
         let ino = *next_ino;
         *next_ino += 1;
         inode_tbl.insert(ino, bucket_path);
     }
-
     info!("S3: Created bucket '{}'", bucket);
     (StatusCode::OK, [(header::CONTENT_TYPE, "application/xml")]).into_response()
 }
 
-/// DELETE /bucket → DeleteBucket
+/// DELETE /bucket → DeleteBucket. A bucket with no *objects* is deletable;
+/// synthetic intermediate directories are swept away with it (S3 has no dirs).
 async fn delete_bucket(state: S3State, bucket: &str) -> Response {
     let bucket_path = PathBuf::from(bucket);
-
     {
         let mut index = state.file_index.write().unwrap();
         let mut inode_tbl = state.inode_table.write().unwrap();
 
-        // Check bucket exists
         match index.get(&bucket_path) {
             Some(e) if !e.is_dir => {
                 return error_response(StatusCode::NOT_FOUND, "NoSuchBucket", "Not a bucket");
@@ -440,94 +508,152 @@ async fn delete_bucket(state: S3State, bucket: &str) -> Response {
             _ => {}
         }
 
-        // Check bucket is empty
-        let has_children = index.iter().any(|(p, _)| {
-            p.starts_with(&bucket_path) && p != &bucket_path
-        });
-
-        if has_children {
+        let mut to_remove: Vec<PathBuf> = Vec::new();
+        let mut has_objects = false;
+        for (p, e) in index.iter() {
+            if *p == bucket_path {
+                to_remove.push(p.clone());
+            } else if p.starts_with(&bucket_path) {
+                if !e.is_dir {
+                    has_objects = true;
+                }
+                to_remove.push(p.clone());
+            }
+        }
+        if has_objects {
             return error_response(
                 StatusCode::CONFLICT,
                 "BucketNotEmpty",
                 "The bucket is not empty",
             );
         }
-
-        index.remove(&bucket_path);
-        inode_tbl.remove_path(&bucket_path);
+        for p in &to_remove {
+            index.remove(p);
+            inode_tbl.remove_path(p);
+        }
     }
-
     info!("S3: Deleted bucket '{}'", bucket);
-    (StatusCode::NO_CONTENT, [(header::CONTENT_TYPE, "application/xml")]).into_response()
+    (
+        StatusCode::NO_CONTENT,
+        [(header::CONTENT_TYPE, "application/xml")],
+    )
+        .into_response()
 }
 
-/// GET /bucket/key → GetObject
-async fn get_object(state: S3State, bucket: &str, key: &str) -> Response {
+// ─── Object operations ───────────────────────────────────────────────────────
+
+/// GET /bucket/key → GetObject (supports Range)
+async fn get_object(state: S3State, bucket: &str, key: &str, headers: &HeaderMap) -> Response {
     let object_path = PathBuf::from(bucket).join(key);
 
-    let index = state.file_index.read().unwrap();
-    let entry = match index.get(&object_path) {
-        Some(e) if !e.is_dir => e.clone(),
-        Some(_) => {
-            return error_response(StatusCode::NOT_FOUND, "NoSuchKey", "Key is a directory");
-        }
-        None => {
-            return error_response(StatusCode::NOT_FOUND, "NoSuchKey", "The specified key does not exist");
+    let entry = {
+        let index = state.file_index.read().unwrap();
+        match index.get(&object_path) {
+            Some(e) if !e.is_dir => e.clone(),
+            Some(_) => {
+                return error_response(StatusCode::NOT_FOUND, "NoSuchKey", "Key is a directory")
+            }
+            None => {
+                return error_response(
+                    StatusCode::NOT_FOUND,
+                    "NoSuchKey",
+                    "The specified key does not exist",
+                )
+            }
         }
     };
-    drop(index);
 
-    // Read all chunk data
-    let data = match state.chunk_store.read(&entry.chunks, 0, entry.size as usize) {
+    let (offset, length, partial) = match parse_range(headers, entry.size) {
+        Some(Ok((start, end))) => (start, (end - start + 1) as usize, true),
+        Some(Err(())) => {
+            return error_response(
+                StatusCode::RANGE_NOT_SATISFIABLE,
+                "InvalidRange",
+                "The requested range is not satisfiable",
+            )
+        }
+        None => (0u64, entry.size as usize, false),
+    };
+
+    let data = match state.chunk_store.read(&entry.chunks, offset, length) {
         Ok(d) => d,
         Err(e) => {
-            error!("S3 GetObject: failed to read chunks for {}/{}: {}", bucket, key, e);
-            return error_response(StatusCode::INTERNAL_SERVER_ERROR, "InternalError", "Failed to read object data");
+            error!("S3 GetObject: failed to read {}/{}: {}", bucket, key, e);
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "InternalError",
+                "Failed to read object data",
+            );
         }
     };
 
-    let etag = if let Some(chunk) = entry.chunks.first() {
-        format!("\"{}\"", hex::encode(&chunk.hash[..16]))
+    let m = state.meta.read().unwrap();
+    let obj_meta = m.get(&meta_key(bucket, key)).cloned().unwrap_or_default();
+    drop(m);
+    let etag = obj_meta
+        .etag
+        .unwrap_or_else(|| first_chunk_etag(&entry.chunks));
+    let content_type = obj_meta
+        .content_type
+        .unwrap_or_else(|| "application/octet-stream".to_string());
+
+    let mut builder = Response::builder();
+    if partial {
+        builder = builder.status(StatusCode::PARTIAL_CONTENT).header(
+            header::CONTENT_RANGE,
+            format!(
+                "bytes {}-{}/{}",
+                offset,
+                offset + length as u64 - 1,
+                entry.size
+            ),
+        );
     } else {
-        "\"d41d8cd98f00b204e9800998ecf8427e\"".to_string()
-    };
-
-    debug!("S3 GetObject: {}/{} ({} bytes)", bucket, key, data.len());
-
-    Response::builder()
-        .status(StatusCode::OK)
-        .header(header::CONTENT_TYPE, "application/octet-stream")
+        builder = builder.status(StatusCode::OK);
+    }
+    builder = builder
+        .header(header::CONTENT_TYPE, content_type)
         .header(header::CONTENT_LENGTH, data.len().to_string())
-        .header("ETag", etag)
-        .header("Last-Modified", format_time_http(&entry.modified))
-        .body(Body::from(data))
-        .unwrap()
+        .header(header::ACCEPT_RANGES, "bytes")
+        .header("ETag", format!("\"{}\"", etag))
+        .header("Last-Modified", format_time_http(&entry.modified));
+    for (k, v) in &obj_meta.user_meta {
+        builder = builder.header(format!("x-amz-meta-{}", k), v.clone());
+    }
+    builder.body(Body::from(data)).unwrap()
 }
 
 /// HEAD /bucket/key → HeadObject
 async fn head_object(state: S3State, bucket: &str, key: &str) -> Response {
     let object_path = PathBuf::from(bucket).join(key);
-
     let index = state.file_index.read().unwrap();
-    match index.get(&object_path) {
-        Some(entry) if !entry.is_dir => {
-            let etag = if let Some(chunk) = entry.chunks.first() {
-                format!("\"{}\"", hex::encode(&chunk.hash[..16]))
-            } else {
-                "\"d41d8cd98f00b204e9800998ecf8427e\"".to_string()
-            };
+    let entry = match index.get(&object_path) {
+        Some(e) if !e.is_dir => e.clone(),
+        _ => return error_response(StatusCode::NOT_FOUND, "NoSuchKey", "Key not found"),
+    };
+    drop(index);
 
-            Response::builder()
-                .status(StatusCode::OK)
-                .header(header::CONTENT_TYPE, "application/octet-stream")
-                .header(header::CONTENT_LENGTH, entry.size.to_string())
-                .header("ETag", etag)
-                .header("Last-Modified", format_time_http(&entry.modified))
-                .body(Body::empty())
-                .unwrap()
-        }
-        _ => error_response(StatusCode::NOT_FOUND, "NoSuchKey", "Key not found"),
+    let m = state.meta.read().unwrap();
+    let obj_meta = m.get(&meta_key(bucket, key)).cloned().unwrap_or_default();
+    drop(m);
+    let etag = obj_meta
+        .etag
+        .unwrap_or_else(|| first_chunk_etag(&entry.chunks));
+    let content_type = obj_meta
+        .content_type
+        .unwrap_or_else(|| "application/octet-stream".to_string());
+
+    let mut builder = Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, content_type)
+        .header(header::CONTENT_LENGTH, entry.size.to_string())
+        .header(header::ACCEPT_RANGES, "bytes")
+        .header("ETag", format!("\"{}\"", etag))
+        .header("Last-Modified", format_time_http(&entry.modified));
+    for (k, v) in &obj_meta.user_meta {
+        builder = builder.header(format!("x-amz-meta-{}", k), v.clone());
     }
+    builder.body(Body::empty()).unwrap()
 }
 
 /// PUT /bucket/key → PutObject
@@ -536,88 +662,16 @@ async fn put_object(
     bucket: &str,
     key: &str,
     data: Vec<u8>,
+    headers: &HeaderMap,
 ) -> Response {
-    let bucket_path = PathBuf::from(bucket);
-    let object_path = bucket_path.join(key);
+    let object_path = PathBuf::from(bucket).join(key);
+    ensure_bucket_and_parents(&state, bucket, &object_path);
 
-    // Ensure bucket exists (auto-create if needed)
-    {
-        let index = state.file_index.read().unwrap();
-        if !index.contains(&bucket_path) {
-            drop(index);
-            // Auto-create the bucket directory
-            let mut index = state.file_index.write().unwrap();
-            let mut inode_tbl = state.inode_table.write().unwrap();
-            if !index.contains(&bucket_path) {
-                let now = SystemTime::now();
-                index.insert(bucket_path.clone(), FileEntry {
-                    size: 0,
-                    is_dir: true,
-                    permissions: 0o755,
-                    uid: 0,
-                    gid: 0,
-                    created: now,
-                    modified: now,
-                    accessed: now,
-                    chunks: Vec::new(),
-                    symlink_target: None,
-                });
-                let mut next_ino = state.next_inode.write().unwrap();
-                let ino = *next_ino;
-                *next_ino += 1;
-                inode_tbl.insert(ino, bucket_path.clone());
-                info!("S3: Auto-created bucket '{}' for PutObject", bucket);
-            }
-        }
-    }
-
-    // Ensure any parent directories in the key path exist
-    if let Some(parent) = object_path.parent() {
-        let mut dirs_to_create = Vec::new();
-        let mut current = parent.to_path_buf();
-        while current != bucket_path && current.components().count() > 0 {
-            dirs_to_create.push(current.clone());
-            if let Some(p) = current.parent() {
-                current = p.to_path_buf();
-            } else {
-                break;
-            }
-        }
-        dirs_to_create.reverse();
-
-        if !dirs_to_create.is_empty() {
-            let mut index = state.file_index.write().unwrap();
-            let mut inode_tbl = state.inode_table.write().unwrap();
-            for dir in dirs_to_create {
-                if !index.contains(&dir) {
-                    let now = SystemTime::now();
-                    index.insert(dir.clone(), FileEntry {
-                        size: 0,
-                        is_dir: true,
-                        permissions: 0o755,
-                        uid: 0,
-                        gid: 0,
-                        created: now,
-                        modified: now,
-                        accessed: now,
-                        chunks: Vec::new(),
-                        symlink_target: None,
-                    });
-                    let mut next_ino = state.next_inode.write().unwrap();
-                    let ino = *next_ino;
-                    *next_ino += 1;
-                    inode_tbl.insert(ino, dir);
-                }
-            }
-        }
-    }
-
-    // Write the object data to chunk store
     let mut chunks: Vec<ChunkRef> = Vec::new();
     let written = match state.chunk_store.write(&mut chunks, 0, &data) {
         Ok(w) => w,
         Err(e) => {
-            error!("S3 PutObject: failed to write chunks for {}/{}: {}", bucket, key, e);
+            error!("S3 PutObject: failed to write {}/{}: {}", bucket, key, e);
             return error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "InternalError",
@@ -626,9 +680,497 @@ async fn put_object(
         }
     };
 
+    let etag = hex::encode(Md5::digest(&data));
+    store_object(&state, &object_path, chunks, written as u64);
+    set_object_meta(
+        &state,
+        bucket,
+        key,
+        S3ObjectMeta {
+            content_type: content_type_of(headers),
+            etag: Some(etag.clone()),
+            user_meta: extract_user_meta(headers),
+        },
+    );
+
+    info!("S3 PutObject: {}/{} ({} bytes)", bucket, key, written);
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("ETag", format!("\"{}\"", etag))
+        .body(Body::empty())
+        .unwrap()
+}
+
+/// DELETE /bucket/key → DeleteObject (idempotent)
+async fn delete_object(state: S3State, bucket: &str, key: &str) -> Response {
+    let object_path = PathBuf::from(bucket).join(key);
+    match remove_object(&state, &object_path) {
+        Ok(()) => {
+            set_object_meta_remove(&state, bucket, key);
+            info!("S3 DeleteObject: {}/{}", bucket, key);
+            (
+                StatusCode::NO_CONTENT,
+                [(header::CONTENT_TYPE, "application/xml")],
+            )
+                .into_response()
+        }
+        Err(()) => error_response(
+            StatusCode::CONFLICT,
+            "InvalidRequest",
+            "Cannot delete a directory as an object",
+        ),
+    }
+}
+
+/// PUT /bucket/key with x-amz-copy-source → CopyObject
+async fn copy_object(
+    state: S3State,
+    dst_bucket: &str,
+    dst_key: &str,
+    raw_source: &str,
+    headers: &HeaderMap,
+) -> Response {
+    // Source format: "/srcbucket/srckey" or "srcbucket/srckey", maybe url-encoded, maybe ?versionId.
+    let src = raw_source.split('?').next().unwrap_or(raw_source);
+    let src = src.strip_prefix('/').unwrap_or(src);
+    let src = percent_encoding::percent_decode_str(src)
+        .decode_utf8_lossy()
+        .to_string();
+    let (src_bucket, src_key) = match src.split_once('/') {
+        Some((b, k)) if !k.is_empty() => (b.to_string(), k.to_string()),
+        _ => {
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                "InvalidArgument",
+                "Malformed x-amz-copy-source",
+            )
+        }
+    };
+
+    let src_path = PathBuf::from(&src_bucket).join(&src_key);
+    let src_entry = {
+        let index = state.file_index.read().unwrap();
+        match index.get(&src_path) {
+            Some(e) if !e.is_dir => e.clone(),
+            _ => return error_response(StatusCode::NOT_FOUND, "NoSuchKey", "Source key not found"),
+        }
+    };
+
+    let dst_path = PathBuf::from(dst_bucket).join(dst_key);
+    let replace = headers
+        .get("x-amz-metadata-directive")
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v.eq_ignore_ascii_case("REPLACE"))
+        .unwrap_or(false);
+    if src_path == dst_path && !replace {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "InvalidRequest",
+            "Copy destination is the same as source without REPLACE directive",
+        );
+    }
+
+    ensure_bucket_and_parents(&state, dst_bucket, &dst_path);
+    // Share chunks by reference (content-addressed); refcount-safe deletes
+    // protect against later corruption.
+    store_object(&state, &dst_path, src_entry.chunks.clone(), src_entry.size);
+
+    // Determine metadata.
+    let src_meta = {
+        let m = state.meta.read().unwrap();
+        m.get(&meta_key(&src_bucket, &src_key))
+            .cloned()
+            .unwrap_or_default()
+    };
+    let etag = src_meta
+        .etag
+        .clone()
+        .unwrap_or_else(|| first_chunk_etag(&src_entry.chunks));
+    let new_meta = if replace {
+        S3ObjectMeta {
+            content_type: content_type_of(headers),
+            etag: Some(etag.clone()),
+            user_meta: extract_user_meta(headers),
+        }
+    } else {
+        S3ObjectMeta {
+            content_type: src_meta.content_type.clone(),
+            etag: Some(etag.clone()),
+            user_meta: src_meta.user_meta.clone(),
+        }
+    };
+    set_object_meta(&state, dst_bucket, dst_key, new_meta);
+
+    let now = SystemTime::now();
+    let xml = format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+         <CopyObjectResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
+         <LastModified>{}</LastModified><ETag>\"{}\"</ETag></CopyObjectResult>",
+        format_time(&now),
+        xml_escape(&etag)
+    );
+    info!(
+        "S3 CopyObject: {}/{} -> {}/{}",
+        src_bucket, src_key, dst_bucket, dst_key
+    );
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "application/xml")],
+        xml,
+    )
+        .into_response()
+}
+
+/// POST /bucket?delete → DeleteObjects (batch)
+async fn delete_objects(state: S3State, bucket: &str, body: &[u8]) -> Response {
+    let (keys, quiet) = match meta::parse_delete(body) {
+        Ok(v) => v,
+        Err(e) => return error_response(StatusCode::BAD_REQUEST, "MalformedXML", &e),
+    };
+
+    let mut xml = String::from("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    xml.push_str("<DeleteResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n");
+    for key in keys {
+        let object_path = PathBuf::from(bucket).join(&key);
+        match remove_object(&state, &object_path) {
+            Ok(()) => {
+                set_object_meta_remove(&state, bucket, &key);
+                if !quiet {
+                    xml.push_str(&format!(
+                        "  <Deleted><Key>{}</Key></Deleted>\n",
+                        xml_escape(&key)
+                    ));
+                }
+            }
+            Err(_) => {
+                xml.push_str(&format!(
+                    "  <Error><Key>{}</Key><Code>InternalError</Code><Message>delete failed</Message></Error>\n",
+                    xml_escape(&key)
+                ));
+            }
+        }
+    }
+    xml.push_str("</DeleteResult>");
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "application/xml")],
+        xml,
+    )
+        .into_response()
+}
+
+// ─── Multipart upload ────────────────────────────────────────────────────────
+
+/// POST /bucket/key?uploads → CreateMultipartUpload
+async fn create_multipart(
+    state: S3State,
+    bucket: &str,
+    key: &str,
+    headers: &HeaderMap,
+) -> Response {
+    let upload_id = hex::encode(rand::random::<[u8; 16]>());
+    let upload = MultipartUpload {
+        bucket: bucket.to_string(),
+        key: key.to_string(),
+        content_type: content_type_of(headers),
+        user_meta: extract_user_meta(headers),
+        parts: BTreeMap::new(),
+    };
+    state
+        .multipart
+        .write()
+        .unwrap()
+        .insert(upload_id.clone(), upload);
+
+    let xml = format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+         <InitiateMultipartUploadResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
+         <Bucket>{}</Bucket><Key>{}</Key><UploadId>{}</UploadId></InitiateMultipartUploadResult>",
+        xml_escape(bucket),
+        xml_escape(key),
+        xml_escape(&upload_id)
+    );
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "application/xml")],
+        xml,
+    )
+        .into_response()
+}
+
+/// PUT /bucket/key?partNumber=&uploadId= → UploadPart
+async fn upload_part(
+    state: S3State,
+    upload_id: &str,
+    part_number: &str,
+    data: Vec<u8>,
+) -> Response {
+    let part_number: u32 = match part_number.parse() {
+        Ok(n) if (1..=10_000).contains(&n) => n,
+        _ => {
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                "InvalidArgument",
+                "Invalid partNumber",
+            )
+        }
+    };
+
+    let mut chunks: Vec<ChunkRef> = Vec::new();
+    if let Err(e) = state.chunk_store.write(&mut chunks, 0, &data) {
+        error!("S3 UploadPart: chunk write failed: {}", e);
+        return error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "InternalError",
+            "Failed to store part",
+        );
+    }
+    let md5_hex = hex::encode(Md5::digest(&data));
+
+    let old_chunks = {
+        let mut uploads = state.multipart.write().unwrap();
+        let upload = match uploads.get_mut(upload_id) {
+            Some(u) => u,
+            None => {
+                return error_response(
+                    StatusCode::NOT_FOUND,
+                    "NoSuchUpload",
+                    "The specified upload does not exist",
+                )
+            }
+        };
+        upload
+            .parts
+            .insert(
+                part_number,
+                PartInfo {
+                    chunks,
+                    md5_hex: md5_hex.clone(),
+                    size: data.len() as u64,
+                },
+            )
+            .map(|p| p.chunks)
+    };
+    // Free chunks of a replaced part (refcount-safe).
+    if let Some(old) = old_chunks {
+        free_chunks_unreferenced(&state, &old);
+    }
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("ETag", format!("\"{}\"", md5_hex))
+        .body(Body::empty())
+        .unwrap()
+}
+
+/// POST /bucket/key?uploadId= → CompleteMultipartUpload
+async fn complete_multipart(
+    state: S3State,
+    bucket: &str,
+    key: &str,
+    upload_id: &str,
+    body: &[u8],
+) -> Response {
+    let requested = match meta::parse_complete_multipart(body) {
+        Ok(v) => v,
+        Err(e) => return error_response(StatusCode::BAD_REQUEST, "MalformedXML", &e),
+    };
+
+    let upload = {
+        let uploads = state.multipart.read().unwrap();
+        match uploads.get(upload_id) {
+            Some(u) => u.clone(),
+            None => {
+                return error_response(
+                    StatusCode::NOT_FOUND,
+                    "NoSuchUpload",
+                    "The specified upload does not exist",
+                )
+            }
+        }
+    };
+
+    // Assemble final chunk list and the multipart ETag.
+    let mut final_chunks: Vec<ChunkRef> = Vec::new();
+    let mut md5_concat: Vec<u8> = Vec::new();
+    let mut total: u64 = 0;
+    let mut last = 0u32;
+    for (num, etag) in &requested {
+        if *num <= last {
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                "InvalidPartOrder",
+                "Parts must be in ascending order",
+            );
+        }
+        last = *num;
+        let part = match upload.parts.get(num) {
+            Some(p) => p,
+            None => {
+                return error_response(
+                    StatusCode::BAD_REQUEST,
+                    "InvalidPart",
+                    &format!("Missing part {}", num),
+                )
+            }
+        };
+        if !etag.trim_matches('"').eq_ignore_ascii_case(&part.md5_hex) {
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                "InvalidPart",
+                &format!("ETag mismatch for part {}", num),
+            );
+        }
+        for c in &part.chunks {
+            final_chunks.push(ChunkRef {
+                hash: c.hash,
+                offset: total + c.offset,
+                size: c.size,
+            });
+        }
+        match hex::decode(&part.md5_hex) {
+            Ok(bytes) => md5_concat.extend_from_slice(&bytes),
+            Err(_) => {
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "InternalError",
+                    "Bad part checksum",
+                )
+            }
+        }
+        total += part.size;
+    }
+    let etag = format!(
+        "{}-{}",
+        hex::encode(Md5::digest(&md5_concat)),
+        requested.len()
+    );
+
+    let object_path = PathBuf::from(bucket).join(key);
+    ensure_bucket_and_parents(&state, bucket, &object_path);
+    store_object(&state, &object_path, final_chunks, total);
+    set_object_meta(
+        &state,
+        bucket,
+        key,
+        S3ObjectMeta {
+            content_type: upload.content_type.clone(),
+            etag: Some(etag.clone()),
+            user_meta: upload.user_meta.clone(),
+        },
+    );
+
+    // Remove the upload from the registry (parts are now part of the object).
+    state.multipart.write().unwrap().remove(upload_id);
+
+    let xml = format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+         <CompleteMultipartUploadResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
+         <Location>/{}/{}</Location><Bucket>{}</Bucket><Key>{}</Key><ETag>\"{}\"</ETag>\
+         </CompleteMultipartUploadResult>",
+        xml_escape(bucket),
+        xml_escape(key),
+        xml_escape(bucket),
+        xml_escape(key),
+        xml_escape(&etag)
+    );
+    info!(
+        "S3 CompleteMultipartUpload: {}/{} ({} bytes, {} parts)",
+        bucket,
+        key,
+        total,
+        requested.len()
+    );
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "application/xml")],
+        xml,
+    )
+        .into_response()
+}
+
+/// DELETE /bucket/key?uploadId= → AbortMultipartUpload
+async fn abort_multipart(state: S3State, upload_id: &str) -> Response {
+    let removed = state.multipart.write().unwrap().remove(upload_id);
+    match removed {
+        Some(upload) => {
+            for part in upload.parts.values() {
+                free_chunks_unreferenced(&state, &part.chunks);
+            }
+            (
+                StatusCode::NO_CONTENT,
+                [(header::CONTENT_TYPE, "application/xml")],
+            )
+                .into_response()
+        }
+        None => error_response(
+            StatusCode::NOT_FOUND,
+            "NoSuchUpload",
+            "The specified upload does not exist",
+        ),
+    }
+}
+
+// ─── Shared object/storage helpers ───────────────────────────────────────────
+
+fn new_dir_entry() -> FileEntry {
+    let now = SystemTime::now();
+    FileEntry {
+        size: 0,
+        is_dir: true,
+        permissions: 0o755,
+        uid: 0,
+        gid: 0,
+        created: now,
+        modified: now,
+        accessed: now,
+        chunks: Vec::new(),
+        symlink_target: None,
+    }
+}
+
+/// Auto-create the bucket directory and any intermediate directories for an
+/// object path (mirrors the FUSE-visible namespace).
+fn ensure_bucket_and_parents(state: &S3State, bucket: &str, object_path: &std::path::Path) {
+    let bucket_path = PathBuf::from(bucket);
+    let mut index = state.file_index.write().unwrap();
+    let mut inode_tbl = state.inode_table.write().unwrap();
+
+    let mut to_create: Vec<PathBuf> = Vec::new();
+    if !index.contains(&bucket_path) {
+        to_create.push(bucket_path.clone());
+    }
+    if let Some(parent) = object_path.parent() {
+        let mut cur = parent.to_path_buf();
+        while cur != bucket_path && cur.components().count() > 0 {
+            if !index.contains(&cur) {
+                to_create.push(cur.clone());
+            }
+            match cur.parent() {
+                Some(p) => cur = p.to_path_buf(),
+                None => break,
+            }
+        }
+    }
+    // Create shallowest first.
+    to_create.sort_by_key(|p| p.components().count());
+    for dir in to_create {
+        if !index.contains(&dir) {
+            index.insert(dir.clone(), new_dir_entry());
+            let mut next_ino = state.next_inode.write().unwrap();
+            let ino = *next_ino;
+            *next_ino += 1;
+            inode_tbl.insert(ino, dir);
+        }
+    }
+}
+
+/// Insert a file entry, allocating an inode and freeing any orphaned chunks of
+/// a replaced entry (reference-counted, dedup-safe).
+fn store_object(state: &S3State, object_path: &std::path::Path, chunks: Vec<ChunkRef>, size: u64) {
     let now = SystemTime::now();
     let entry = FileEntry {
-        size: written as u64,
+        size,
         is_dir: false,
         permissions: 0o644,
         uid: 0,
@@ -636,87 +1178,198 @@ async fn put_object(
         created: now,
         modified: now,
         accessed: now,
-        chunks: chunks.clone(),
+        chunks,
         symlink_target: None,
     };
 
-    // Insert into index
+    let mut index = state.file_index.write().unwrap();
+    let mut inode_tbl = state.inode_table.write().unwrap();
+    let old = index.insert(object_path.to_path_buf(), entry);
+    if inode_tbl.get_inode(&object_path.to_path_buf()).is_none() {
+        let mut next_ino = state.next_inode.write().unwrap();
+        let ino = *next_ino;
+        *next_ino += 1;
+        inode_tbl.insert(ino, object_path.to_path_buf());
+    }
+    if let Some(old) = old {
+        if !old.is_dir {
+            free_chunks_with_index(state, &index, &old.chunks);
+        }
+    }
+}
+
+/// Remove an object entry (idempotent), freeing orphaned chunks. Returns
+/// `Err(())` only when the path names a directory (not deletable as an object).
+fn remove_object(state: &S3State, object_path: &std::path::Path) -> Result<(), ()> {
+    let mut index = state.file_index.write().unwrap();
+    let mut inode_tbl = state.inode_table.write().unwrap();
+    match index.remove(object_path) {
+        Some(entry) if !entry.is_dir => {
+            inode_tbl.remove_path(&object_path.to_path_buf());
+            free_chunks_with_index(state, &index, &entry.chunks);
+            Ok(())
+        }
+        Some(entry) => {
+            index.insert(object_path.to_path_buf(), entry);
+            Err(())
+        }
+        None => Ok(()),
+    }
+}
+
+/// Delete each chunk not referenced by any remaining index entry OR any
+/// in-flight multipart part. Takes an already-held index reference (lock order:
+/// file_index before multipart). Reference-counted so deduplicated chunks shared
+/// by other objects/parts are never deleted out from under them.
+fn free_chunks_with_index(state: &S3State, index: &FileIndex, chunks: &[ChunkRef]) {
+    let uploads = state.multipart.read().unwrap();
+    let mut seen: HashSet<[u8; 32]> = HashSet::new();
+    for c in chunks {
+        if !seen.insert(c.hash) {
+            continue;
+        }
+        let in_index = index
+            .iter()
+            .any(|(_, e)| e.chunks.iter().any(|x| x.hash == c.hash));
+        let in_parts = uploads.values().any(|u| {
+            u.parts
+                .values()
+                .any(|p| p.chunks.iter().any(|x| x.hash == c.hash))
+        });
+        if !in_index && !in_parts {
+            let _ = state.chunk_store.delete(&c.hash);
+        }
+    }
+}
+
+/// Same as `free_chunks_with_index` but acquires the index read lock itself
+/// (used when no index guard is held, e.g. multipart part replacement/abort).
+fn free_chunks_unreferenced(state: &S3State, chunks: &[ChunkRef]) {
+    let index = state.file_index.read().unwrap();
+    free_chunks_with_index(state, &index, chunks);
+}
+
+fn set_object_meta(state: &S3State, bucket: &str, key: &str, m: S3ObjectMeta) {
     {
-        let mut index = state.file_index.write().unwrap();
-        let mut inode_tbl = state.inode_table.write().unwrap();
+        let mut store = state.meta.write().unwrap();
+        store.put(meta_key(bucket, key), m);
+    }
+    persist_meta(state);
+}
 
-        let old = index.insert(object_path.clone(), entry);
+fn set_object_meta_remove(state: &S3State, bucket: &str, key: &str) {
+    {
+        let mut store = state.meta.write().unwrap();
+        store.remove(&meta_key(bucket, key));
+    }
+    persist_meta(state);
+}
 
-        // Clean up old chunks if overwriting
-        if let Some(old_entry) = old {
-            if !old_entry.is_dir {
-                for chunk in &old_entry.chunks {
-                    let _ = state.chunk_store.delete(&chunk.hash);
-                }
+fn persist_meta(state: &S3State) {
+    let store = state.meta.read().unwrap();
+    if let Err(e) = store.save(&state.meta_path) {
+        error!("S3: failed to persist metadata sidecar: {}", e);
+    }
+}
+
+fn meta_key(bucket: &str, key: &str) -> String {
+    format!("{}/{}", bucket, key)
+}
+
+/// ETag for listings: prefer the stored S3 ETag, else fall back to the legacy
+/// first-chunk scheme.
+fn object_etag(meta: &S3MetaStore, bucket: &str, key: &str, chunks: &[ChunkRef]) -> String {
+    meta.get(&meta_key(bucket, key))
+        .and_then(|m| m.etag.clone())
+        .unwrap_or_else(|| first_chunk_etag(chunks))
+}
+
+fn first_chunk_etag(chunks: &[ChunkRef]) -> String {
+    match chunks.first() {
+        Some(c) => hex::encode(&c.hash[..16]),
+        None => "d41d8cd98f00b204e9800998ecf8427e".to_string(),
+    }
+}
+
+fn content_type_of(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get(header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string())
+        .filter(|s| !s.is_empty() && s != "application/octet-stream")
+}
+
+fn extract_user_meta(headers: &HeaderMap) -> HashMap<String, String> {
+    let mut meta = HashMap::new();
+    for (name, value) in headers.iter() {
+        if let Some(k) = name.as_str().strip_prefix("x-amz-meta-") {
+            if let Ok(v) = value.to_str() {
+                meta.insert(k.to_string(), v.to_string());
             }
         }
-
-        // Allocate inode if new
-        if inode_tbl.get_inode(&object_path).is_none() {
-            let mut next_ino = state.next_inode.write().unwrap();
-            let ino = *next_ino;
-            *next_ino += 1;
-            inode_tbl.insert(ino, object_path);
-        }
     }
+    meta
+}
 
-    let etag = if let Some(chunk) = chunks.first() {
-        format!("\"{}\"", hex::encode(&chunk.hash[..16]))
+fn is_streaming(headers: &HeaderMap) -> bool {
+    let sha_streaming = headers
+        .get("x-amz-content-sha256")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.starts_with("STREAMING-"))
+        .unwrap_or(false);
+    let enc_chunked = headers
+        .get(header::CONTENT_ENCODING)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.contains("aws-chunked"))
+        .unwrap_or(false);
+    sha_streaming || enc_chunked
+}
+
+/// Parse a Range header into an inclusive (start, end), clamped to `size`.
+/// None = no range; Some(Err) = unsatisfiable.
+fn parse_range(headers: &HeaderMap, size: u64) -> Option<Result<(u64, u64), ()>> {
+    let raw = headers.get(header::RANGE)?.to_str().ok()?;
+    let spec = raw.strip_prefix("bytes=")?;
+    let spec = spec.split(',').next().unwrap_or(spec).trim();
+    if size == 0 {
+        return Some(Err(()));
+    }
+    let (start_s, end_s) = spec.split_once('-')?;
+    let result = if start_s.is_empty() {
+        match end_s.parse::<u64>() {
+            Ok(n) if n > 0 => {
+                let n = n.min(size);
+                Ok((size - n, size - 1))
+            }
+            _ => Err(()),
+        }
     } else {
-        "\"d41d8cd98f00b204e9800998ecf8427e\"".to_string()
-    };
-
-    info!("S3 PutObject: {}/{} ({} bytes)", bucket, key, written);
-
-    Response::builder()
-        .status(StatusCode::OK)
-        .header("ETag", etag)
-        .body(Body::empty())
-        .unwrap()
-}
-
-/// DELETE /bucket/key → DeleteObject
-async fn delete_object(state: S3State, bucket: &str, key: &str) -> Response {
-    let object_path = PathBuf::from(bucket).join(key);
-
-    let chunks_to_delete = {
-        let mut index = state.file_index.write().unwrap();
-        let mut inode_tbl = state.inode_table.write().unwrap();
-
-        match index.remove(&object_path) {
-            Some(entry) if !entry.is_dir => {
-                inode_tbl.remove_path(&object_path);
-                entry.chunks
+        let start: u64 = match start_s.parse() {
+            Ok(v) => v,
+            Err(_) => return Some(Err(())),
+        };
+        if start >= size {
+            return Some(Err(()));
+        }
+        let end = if end_s.is_empty() {
+            size - 1
+        } else {
+            match end_s.parse::<u64>() {
+                Ok(v) => v.min(size - 1),
+                Err(_) => return Some(Err(())),
             }
-            Some(entry) => {
-                // Put it back — can't delete a directory this way
-                index.insert(object_path, entry);
-                return error_response(StatusCode::CONFLICT, "InvalidRequest", "Cannot delete a directory as an object");
-            }
-            None => {
-                // S3 spec: DELETE on non-existent key returns 204
-                Vec::new()
-            }
+        };
+        if end < start {
+            Err(())
+        } else {
+            Ok((start, end))
         }
     };
-
-    // Delete chunks
-    for chunk in &chunks_to_delete {
-        let _ = state.chunk_store.delete(&chunk.hash);
-    }
-
-    info!("S3 DeleteObject: {}/{}", bucket, key);
-    (StatusCode::NO_CONTENT, [(header::CONTENT_TYPE, "application/xml")]).into_response()
+    Some(result)
 }
 
-// ─── Helpers ─────────────────────────────────────────────────────────────────
+// ─── Generic helpers (unchanged) ─────────────────────────────────────────────
 
-/// Parse a request path into (bucket, optional key)
 fn parse_bucket_key(path: &str) -> (String, Option<String>) {
     let path = path.trim_start_matches('/');
     if let Some(slash_pos) = path.find('/') {
@@ -732,52 +1385,35 @@ fn parse_bucket_key(path: &str) -> (String, Option<String>) {
     }
 }
 
-/// Check authorization
-fn authorize(headers: &HeaderMap, credentials: &Option<S3Credentials>) -> bool {
-    let auth_header = headers
-        .get(header::AUTHORIZATION)
-        .and_then(|v| v.to_str().ok());
-    check_auth(auth_header, credentials.as_ref())
-}
-
-/// Format a SystemTime as ISO 8601 for S3 XML responses
 fn format_time(time: &SystemTime) -> String {
     let duration = time.duration_since(UNIX_EPOCH).unwrap_or_default();
     let secs = duration.as_secs();
-    
-    // Simple UTC formatting
     let days = secs / 86400;
     let time_of_day = secs % 86400;
     let hours = time_of_day / 3600;
     let minutes = (time_of_day % 3600) / 60;
     let seconds = time_of_day % 60;
-
-    // Approximate date calculation (good enough for S3 responses)
     let (year, month, day) = days_to_ymd(days);
-
     format!(
         "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}.000Z",
         year, month, day, hours, minutes, seconds
     )
 }
 
-/// Format a SystemTime as HTTP date (RFC 7231)
 fn format_time_http(time: &SystemTime) -> String {
     let duration = time.duration_since(UNIX_EPOCH).unwrap_or_default();
     let secs = duration.as_secs();
-
     let days = secs / 86400;
     let time_of_day = secs % 86400;
     let hours = time_of_day / 3600;
     let minutes = (time_of_day % 3600) / 60;
     let seconds = time_of_day % 60;
-
-    let day_of_week = ((days + 4) % 7) as usize; // Jan 1, 1970 was Thursday
+    let day_of_week = ((days + 4) % 7) as usize;
     let dow = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-    let months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
-
+    let months = [
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    ];
     let (year, month, day) = days_to_ymd(days);
-
     format!(
         "{}, {:02} {} {:04} {:02}:{:02}:{:02} GMT",
         dow[day_of_week],
@@ -790,9 +1426,7 @@ fn format_time_http(time: &SystemTime) -> String {
     )
 }
 
-/// Convert days since epoch to (year, month, day)
 fn days_to_ymd(days: u64) -> (u64, u64, u64) {
-    // Civil calendar calculation from days since epoch
     let z = days + 719468;
     let era = z / 146097;
     let doe = z - era * 146097;
@@ -806,7 +1440,6 @@ fn days_to_ymd(days: u64) -> (u64, u64, u64) {
     (y, m, d)
 }
 
-/// XML-escape a string
 fn xml_escape(s: &str) -> String {
     s.replace('&', "&amp;")
         .replace('<', "&lt;")
@@ -815,20 +1448,12 @@ fn xml_escape(s: &str) -> String {
         .replace('\'', "&apos;")
 }
 
-/// Build an S3 error XML response
 fn error_response(status: StatusCode, code: &str, message: &str) -> Response {
     let xml = format!(
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
-         <Error>\n\
-         <Code>{}</Code>\n\
-         <Message>{}</Message>\n\
-         </Error>",
-        code, xml_escape(message)
+         <Error>\n<Code>{}</Code>\n<Message>{}</Message>\n</Error>",
+        code,
+        xml_escape(message)
     );
-
-    (
-        status,
-        [(header::CONTENT_TYPE, "application/xml")],
-        xml,
-    ).into_response()
+    (status, [(header::CONTENT_TYPE, "application/xml")], xml).into_response()
 }


### PR DESCRIPTION
## Summary

Brings the WolfDisk S3 gateway (`wolfdisk/src/s3/`) up to real S3 compatibility and fixes a startup panic.

**Two pre-existing bugs fixed:**
- The S3 server **panicked on boot** when `[s3] enabled = true` — the catch-all route used axum-0.8 syntax (`/{*path}`) but the crate resolves to **axum 0.7** (`/*path`). Unnoticed because `s3.enabled` defaults to false.
- Auth only **string-matched the access key** — the SigV4 signature/secret were never verified, so anyone knowing the (non-secret) access key was "authenticated".

**New capabilities:**
- **Real AWS SigV4** verification — header-based + presigned, constant-time compare, clock-skew check, and `aws-chunked` (streaming) body decoding. Verified against the AWS-published example vector. *No credentials configured still means "allow all"* (unchanged private-cluster behaviour).
- **Multipart upload** (Create/UploadPart/Complete/Abort), **CopyObject**, **DeleteObjects** (batch), **Range** GET (206), correct **MD5 ETags** (`<md5>-N` for multipart), **Content-Type** and **`x-amz-meta-*`** user metadata.
- **Reference-counted chunk deletion** in S3 delete/overwrite paths — deleting one of two identical (deduplicated) objects no longer corrupts the other.

## Blast radius

Contained to `src/s3/*` plus a 2-line wiring change in `main.rs`. **No changes** to `FileEntry`, FUSE, replication, or the index/wire format. S3 object metadata is kept in a node-local sidecar (`<data_dir>/index/s3_meta.json`), consistent with how the existing `symlink_target` field is not replicated.

## Testing

- 12 unit tests (SigV4 vector, aws-chunked decode, XML parsing, constant-time compare).
- Live end-to-end against the real `wolfdisk mount` binary driven by an independent stdlib SigV4 client: every operation incl. multipart, copy, batch delete, range, metadata, **streaming upload**, bad-signature → 403, and dedup-safe delete/overwrite/abort.
- Bidirectional FUSE↔S3 visibility verified on a shared data dir.
- `cargo build` + `cargo clippy` clean on the new code.

## Known limitations (documented)

- Single PUT / part bodies buffer in memory up to 512 MB (use multipart for larger).
- Per-chunk streaming signatures aren't individually re-verified (request is authenticated by its seed signature).
- ACLs, versioning, and bucket policies are not implemented.

Built by CodeWolf & Wolf Software Systems Ltd
