### PR TITLE
replication: fix test build drift so cargo test compiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3298,7 +3298,7 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "wolfscale"
-version = "5.5.8"
+version = "5.5.9"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src/replication/follower.rs
+++ b/src/replication/follower.rs
@@ -711,7 +711,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let (tx, _rx) = mpsc::channel(100);
 
-        let wal_writer = WalWriter::new(
+        let wal_writer = crate::wal::WalWriter::new(
             dir.path().to_path_buf(),
             test_wal_config(),
             "follower".to_string(),

--- a/src/replication/leader.rs
+++ b/src/replication/leader.rs
@@ -741,6 +741,7 @@ mod tests {
             cluster,
             ReplicationConfig::default(),
             tx,
+            None,
         );
     }
 }

--- a/src/replication/protocol.rs
+++ b/src/replication/protocol.rs
@@ -285,13 +285,14 @@ mod tests {
             term: 1,
             leader_id: "node-1".to_string(),
             commit_lsn: 100,
+            members: vec![],
         };
 
         let bytes = msg.serialize().unwrap();
         let restored = Message::deserialize(&bytes).unwrap();
 
         match restored {
-            Message::Heartbeat { term, leader_id, commit_lsn } => {
+            Message::Heartbeat { term, leader_id, commit_lsn, .. } => {
                 assert_eq!(term, 1);
                 assert_eq!(leader_id, "node-1");
                 assert_eq!(commit_lsn, 100);


### PR DESCRIPTION
## Summary

The `wolfscale` lib-test target failed to compile (5 errors), so `cargo test` was broken at the repo root. The library built fine, which is why it slipped through — the breakage was test code that had drifted from the current lib API.

## Fixes (test-only)

- **protocol.rs** — `Message::Heartbeat` gained a `members: Vec<(String, String)>` field; added it to the test constructor and ignore it (`..`) in the match.
- **leader.rs** — `LeaderNode::new` gained an 8th `executor: Option<Arc<MariaDbExecutor>>` argument; pass `None` in the test.
- **follower.rs** — qualify `WalWriter` as `crate::wal::WalWriter` in the test (the type was never imported into this module).

No production code paths changed.

## Testing

`cargo test` — **44 passed, 0 failed**.

Built by CodeWolf & Wolf Software Systems Ltd
