### PR TITLE
ci: install pinned cross release instead of git HEAD (fixes release builds)

### DIFF
--- a/.github/workflows/wolfdisk-docker-publish.yml
+++ b/.github/workflows/wolfdisk-docker-publish.yml
@@ -35,7 +35,9 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Install cross
-        run: cargo install cross --git https://github.com/cross-rs/cross
+        # Install the published release with its pinned lockfile (git HEAD fails
+        # to compile on the runner's toolchain).
+        run: cargo install cross --locked
         working-directory: .
 
       - name: Build static binaries

--- a/.github/workflows/wolfdisk-release.yml
+++ b/.github/workflows/wolfdisk-release.yml
@@ -37,7 +37,10 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Install cross
-        run: cargo install cross --git https://github.com/cross-rs/cross
+        # Install the published release with its pinned lockfile. Building cross
+        # from git HEAD broke (its `directories 6`/`dirs-sys 0.5.0` dep needs a
+        # newer toolchain than the runner provides).
+        run: cargo install cross --locked
         working-directory: .
 
       - name: Build static binaries

--- a/.github/workflows/wolfscale-release.yml
+++ b/.github/workflows/wolfscale-release.yml
@@ -31,7 +31,9 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Install cross
-        run: cargo install cross --git https://github.com/cross-rs/cross
+        # Install the published release with its pinned lockfile (git HEAD fails
+        # to compile on the runner's toolchain).
+        run: cargo install cross --locked
 
       - name: Build static binaries
         run: cross build --release --target ${{ matrix.target }} --bin wolfscale --bin wolfctl


### PR DESCRIPTION
## Summary

"WolfDisk — Build Release Binaries" (and the docker + wolfscale release workflows) started failing at the **Install cross** step — before any project code is built.

Root cause: they install cross with `cargo install cross --git https://github.com/cross-rs/cross`. Building cross from git HEAD now pulls `directories ^6.0` → `dirs-sys 0.5.0`, which requires a newer toolchain than the runner provides, so `cargo install` aborts with exit 101. The recent `wolfdisk/s3` merge merely re-triggered the workflow; the breakage is the unpinned git install.

## Fix

Use `cargo install cross --locked`, which installs the published **cross 0.2.5** with its bundled lockfile (pinned, buildable deps). Applied to all three affected workflows:
- `.github/workflows/wolfdisk-release.yml`
- `.github/workflows/wolfdisk-docker-publish.yml`
- `.github/workflows/wolfscale-release.yml`

## Validation

- `cargo install cross --locked` runs to completion locally (the exact step that failed in CI).
- `cross build --release --target x86_64-unknown-linux-musl` of the `wolfdisk` crate validated locally with Docker.

Built by CodeWolf & Wolf Software Systems Ltd
