### PR TITLE
wolfdisk: bump version to 2.8.0 for the S3 gateway feature

### DIFF
--- a/wolfdisk/Cargo.lock
+++ b/wolfdisk/Cargo.lock
@@ -2459,7 +2459,7 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "wolfdisk"
-version = "2.7.7"
+version = "2.8.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/wolfdisk/Cargo.toml
+++ b/wolfdisk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wolfdisk"
-version = "2.7.7"
+version = "2.8.0"
 edition = "2021"
 authors = ["Wolf Software Systems Ltd"]
 description = "Distributed file system with replicated and shared storage modes"


### PR DESCRIPTION
Bumps `wolfdisk` 2.7.7 → 2.8.0 so the merged S3 gateway feature (SigV4 auth, multipart, copy, batch delete, range, metadata) ships under its own release tag (`v2.8.0-wolfdisk`) instead of overwriting 2.7.7.

Only `wolfdisk/Cargo.toml` + `Cargo.lock` change; the CLI reports the version via `env!("CARGO_PKG_VERSION")` and the release workflow reads it from `Cargo.toml`, so no other edits are needed.

Built by CodeWolf & Wolf Software Systems Ltd